### PR TITLE
Add path parameter to exec_sysctl_* Exec

### DIFF
--- a/manifests/value.pp
+++ b/manifests/value.pp
@@ -14,6 +14,7 @@ define sysctl::value (
   }
   exec {
     "exec_sysctl_${real_key}" :
+      path    => "/sbin:/bin:/usr/bin",
       command => $::kernel ? {
         openbsd => "sysctl ${real_key}=\"${value}\"",
         default => "sysctl -w ${real_key}=\"${value}\""


### PR DESCRIPTION
Puppet 2.7.11 fails with "'sysctl ...' is not qualified and no path was specified." This commit resolves the issue by adding a path parameter to the exec resource in the `sysctl::value` define.
