### PR TITLE
Add path to Exec[exec_sysctl_*]

### DIFF
--- a/manifests/value.pp
+++ b/manifests/value.pp
@@ -30,5 +30,6 @@ define sysctl::value (
       command => $command,
       unless  => $unless,
       require => Sysctl[$real_key],
+      path => "/usr/sbin:/usr/bin:/sbin:/bin"
   }
 }


### PR DESCRIPTION
Without this patch, I get this error:

```
Parameter unless failed: 'sysctl some.value | grep -q ' = 0'' is not qualified and no path was specified. Please qualify the command or specify a path.
```
