### PR TITLE
if no default provider specified use nil

### DIFF
--- a/lib/puppet/type/sysctl.rb
+++ b/lib/puppet/type/sysctl.rb
@@ -31,7 +31,8 @@ module Puppet
 
         newproperty(:target) do
             desc "Name of the file to store parameters in"
-            defaultto { if @resource.class.defaultprovider.ancestors.include?(Puppet::Provider::ParsedFile)
+            defaultto { if @resource.class.defaultprovider and
+                           @resource.class.defaultprovider.ancestors.include?(Puppet::Provider::ParsedFile)
                             @resource.class.defaultprovider.default_target
                         else
                             nil


### PR DESCRIPTION
```
rspec-puppet gives an error otherwise

  Failure/Error: it { should compile.with_all_deps }
   NoMethodError:
      undefined method `ancestors' for nil:NilClass
       # ./modules/vendor/sysctl/lib/puppet/type/sysctl.rb:34:in
       # `default'
```
