### PR TITLE
set path on exec_sysctl_${key}

### DIFF
--- a/manifests/value.pp
+++ b/manifests/value.pp
@@ -35,5 +35,6 @@ define sysctl::value (
       command => $command,
       unless  => $unless,
       require => Sysctl[$key],
+      path    => ['/sbin', '/usr/sbin', '/bin', '/usr/bin'],
   }
 }


### PR DESCRIPTION
If a module sets a path missing `/sbin` as global resource defaults for Exec, sysctl isn't found.
