### PR TITLE
create /etc/sysctl.conf if it doesn't yet exist

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,4 +6,11 @@
 #               don't want to set a global exec default.
 class sysctl::params(
   $exec_path = undef,
-) { }
+) {
+  file { '/etc/sysctl.conf':
+    ensure      => 'present',
+    owner       => 'root',
+    group       => '0',
+    mode        => '0644',
+  }
+}

--- a/manifests/value.pp
+++ b/manifests/value.pp
@@ -7,12 +7,14 @@ define sysctl::value (
   $value,
   $key    = $name,
 ) {
+  include sysctl::params
 
   $array = split($value,'[\s\t]')
   $val1 = inline_template("<%= @array.reject(&:empty?).flatten.join(\"\t\") %>")
 
   sysctl { $key :
-    val => $val1,
+    val     => $val1,
+    require => File['/etc/sysctl.conf'],
   }
 
   $command = $::kernel ? {
@@ -35,7 +37,6 @@ define sysctl::value (
       require => Sysctl[$key],
   }
 
-  include sysctl::params
   if $sysctl::params::exec_path {
     Exec["exec_sysctl_${key}"]{
       path => $sysctl::params::exec_path


### PR DESCRIPTION
This adds a class sysctl::file in order to create the file, in case it doesn't exist. OpenBSD -current and future 5.6 may not have a sysctl.conf file per default, therefore it must be ensured that it exists before attempting to set a sysctl value.
