### PR TITLE
Create class wrapper for compatibility with Hiera

### DIFF
--- a/manifests/values.pp
+++ b/manifests/values.pp
@@ -1,0 +1,18 @@
+#
+# Author: Emilien Macchi <emilien@redhat.com>
+#
+# == Class: sysctl::values
+#
+# Class wrapper to create sysctl values with Hiera.
+#
+# === Parameters:
+#
+# [*args*] A sysctl config hash
+#   Required.
+#
+# [*defaults*] A config hash
+#   Optional. Defaults to a empty hash
+#
+class sysctl::values($args, $defaults = {}) {
+  create_resources(sysctl::value, $args, $defaults)
+}

--- a/spec/classes/sysctl_values_spec.rb
+++ b/spec/classes/sysctl_values_spec.rb
@@ -1,0 +1,49 @@
+#
+# Author: Emilien Macchi <emilien@redhat.com>
+#
+require 'spec_helper'
+
+describe 'sysctl::values' do
+
+  shared_examples_for 'sysctl values' do
+    let :params do
+      {
+        :args => {
+          'net.ipv4.ip_forward' => {
+            'value' => '1',
+          },
+          'net.ipv6.conf.all.forwarding' => {
+            'value' => '1',
+          },
+        },
+      }
+    end
+
+    it {
+      is_expected.to contain_sysctl('net.ipv4.ip_forward').with('val' => "1")
+      is_expected.to contain_sysctl('net.ipv6.conf.all.forwarding').with('val' => "1")
+    }
+  end
+
+  describe 'Debian' do
+    let :facts do
+      {
+        :osfamily => 'Debian',
+      }
+    end
+
+    it_configures 'sysctl values'
+  end
+
+
+  describe 'RHEL' do
+    let :facts do
+      {
+        :osfamily => 'RedHat',
+      }
+    end
+
+    it_configures 'sysctl values'
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,4 +5,5 @@ fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
 RSpec.configure do |c|
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')
+  c.alias_it_should_behave_like_to(:it_configures, 'configures')
 end


### PR DESCRIPTION
Allow to easily create a sysctl resource using Hiera.

Here is an example of usage:
```
 sysctl::values:
   net.ipv4.ip_forward:
     value: 1
   net.ipv6.conf.all.forwarding:
     value: 1
```