### PR TITLE
Implement ::sysctl class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,5 @@
 # common things for sysctl
-class sysctl::base {
-
-  warning('This class will be deprecated in a future release, you should use ::sysctl instead.')
-
+class sysctl {
   file { '/etc/sysctl.conf':
     ensure => 'present',
     owner  => 'root',

--- a/spec/classes/sysctl_init_spec.rb
+++ b/spec/classes/sysctl_init_spec.rb
@@ -1,0 +1,38 @@
+#
+# Author: Emilien Macchi <emilien@redhat.com>
+#
+require 'spec_helper'
+
+describe 'sysctl' do
+
+  shared_examples_for 'sysctl' do
+    it { is_expected.to contain_file('/etc/sysctl.conf').with(
+      'ensure' => 'present',
+      'owner'  => 'root',
+      'group'  => '0',
+      'mode'   => '0644',
+    )}
+  end
+
+  describe 'Debian' do
+    let :facts do
+      {
+        :osfamily => 'Debian',
+      }
+    end
+
+    it_configures 'sysctl'
+  end
+
+
+  describe 'RHEL' do
+    let :facts do
+      {
+        :osfamily => 'RedHat',
+      }
+    end
+
+    it_configures 'sysctl'
+  end
+
+end


### PR DESCRIPTION
In Puppet, the convention says we should have ::sysctl basic class (for
common things) represented by init.pp manifest.

This patch aims to:
- create this new class
- create associated rspec tests
- add a warning to sysctl::base to explain that we should use ::sysctl
  and this class will be deprecated one day.
