### PR TITLE
Fix warning on Puppet 4

### DIFF
--- a/lib/puppet/type/sysctl.rb
+++ b/lib/puppet/type/sysctl.rb
@@ -1,5 +1,4 @@
-module Puppet
-    newtype(:sysctl) do
+Puppet::Type.newtype(:sysctl) do
 
         @doc = "Manages kernel parameters in /etc/sysctl.conf.  By default this will
                 only edit the configuration file, and not change any of the runtime
@@ -39,5 +38,4 @@ module Puppet
                         end
             }
         end
-    end
 end


### PR DESCRIPTION
The module causes the following warning message when used with Puppet 4:

`Puppet.newtype is deprecated and will be removed in a future release. Use Puppet::Type.newtype instead.`

This patch fixes the warning. I left the remaining Ruby code unmodified to make the change obvious. But it is probably a 
good idea to also adjust the code indentation when commiting this fix.

