### PR TITLE
Print warning and dont fail on non-existent key

### DIFF
--- a/lib/puppet/provider/sysctl_runtime/sysctl_runtime.rb
+++ b/lib/puppet/provider/sysctl_runtime/sysctl_runtime.rb
@@ -35,7 +35,7 @@ Puppet::Type.type(:sysctl_runtime).provide(:sysctl_runtime, :parent => Puppet::P
       if provider = sysctl_flags.find{ |sres| sres.name == res }
         resources[res].provider = provider
       else
-        raise(Puppet::ParseError, "sysctl parameter #{res} wasn't found on this system")
+        Puppet.warning("sysctl parameter #{res} wasn't found on this system")
       end
     end
   end


### PR DESCRIPTION
Dont fail with a ParseError that stops the whole
execution if the provided sysctl key does not exist.

Issue: #44