### PR TITLE
make sysctl::values::args optional

### DIFF
--- a/manifests/values.pp
+++ b/manifests/values.pp
@@ -13,9 +13,15 @@
 #
 # @api public
 class sysctl::values(
-  Hash $args,
+  Optional[Hash] $args = undef,
   Hash $defaults = {},
 ) {
 
-  create_resources(sysctl::value, $args, $defaults)
+  if ($args) {
+    $args.each |$name, $value| {
+      sysctl::value { $name:
+        * => $defaults + $value,
+      }
+    }
+  }
 }

--- a/spec/classes/sysctl_values_spec.rb
+++ b/spec/classes/sysctl_values_spec.rb
@@ -21,11 +21,47 @@ describe 'sysctl::values' do
     }
   end
 
+  shared_examples 'sysctl::values with defaults' do
+    let :params do
+      {
+        args: {
+          'net.ipv4.ip_forward' => {
+            'value'  => '1',
+            'target' => '/dne/bar.conf',
+          },
+          'net.ipv6.conf.all.forwarding' => {},
+        },
+        defaults: {
+          'target' => '/dne/foo.conf',
+          'value'  => 42,
+        }
+      }
+    end
+
+    it do
+      is_expected.to contain_sysctl('net.ipv4.ip_forward').with(
+        val: '1',
+        target: '/dne/bar.conf',
+      )
+    end
+    it do
+      is_expected.to contain_sysctl('net.ipv6.conf.all.forwarding').with(
+        val: '42',
+        target: '/dne/foo.conf',
+      )
+    end
+  end
+
   on_supported_os({
     :supported_os => SUPPORTED_OS
   }).each do |os, facts|
     context "on #{os}" do
       it_behaves_like 'sysctl::values'
+      it_behaves_like 'sysctl::values with defaults'
     end
+  end
+
+  context 'does not fail with no args params' do
+    it { is_expected.to compile.with_all_deps }
   end
 end


### PR DESCRIPTION
Currently, if `sysctl::values` is included in the manifest, there must be
a `sysctl::values::args` key declared in hiera for all nodes.  This
change allows `sysctl::values` to always be included in the manifest
even if no sysctls are being managed.